### PR TITLE
Only hide the sidebar header for Tab Center Redux.

### DIFF
--- a/Styles/userChromeTabCenter.css
+++ b/Styles/userChromeTabCenter.css
@@ -8,7 +8,7 @@
  * sidebar, a-la Tab Center. */
 
 /*Remove sidebar header*/
-#sidebar-header {
+#sidebar-box[sidebarcommand="_0ad88674-2b41-4cfb-99e3-e206c74a0076_-sidebar-action"] > #sidebar-header {
   visibility: collapse !important;
 }
 


### PR DESCRIPTION
The string "0ad88674-2b41-4cfb-99e3-e206c74a0076" is Tab Center Redux's
extension ID, we can use this to only hide the header when Tab Center
Redux occupies the sidebar.